### PR TITLE
Add class and property node types to the printer

### DIFF
--- a/passes/format/printer.go
+++ b/passes/format/printer.go
@@ -44,6 +44,22 @@ func (f *formatWalker) printNode(node ast.Node) {
 		for _, stmt := range n.Statements {
 			f.Walk(stmt)
 		}
+	case ast.Class:
+		f.printToken(token.Class)
+		f.printf(" %s {", n.Name)
+		f.tabLevel += 1
+		for _, child := range n.Children() {
+			f.Walk(child)
+		}
+	case ast.Property:
+		f.printTabbedLine()
+		f.printVisibility(n.Visibility)
+		f.printf(" %s", n.Name)
+		if n.Initialization != nil {
+			f.print(" = ")
+			f.printNode(n.Initialization)
+		}
+		f.print(";")
 	default:
 		f.printTabbedLine()
 		f.printf("// unimplemented %T\n", n)
@@ -105,4 +121,14 @@ func (f *formatWalker) printTabbedLine() {
 
 func (f *formatWalker) println() {
 	io.WriteString(f.w, "\n")
+}
+
+var visibilityMap = map[ast.Visibility]string{
+	ast.Private:   "private",
+	ast.Protected: "protected",
+	ast.Public:    "public",
+}
+
+func (f *formatWalker) printVisibility(v ast.Visibility) {
+	f.print(visibilityMap[v])
 }


### PR DESCRIPTION
Just checking out your `fmt` command line tool, looks interesting. The parser works quite well, but obviously more work needed to make fmt useful.

Is what I've done here on the right track?

One thing I've noticed about gofmt is that it preserves whitespace, but normalises it... but It seems that this php parser is just dropping all whitespace at present. Is that intentional, or how do you see a php fmt tool dealing with whitespace?
