### PR TITLE
Override repo language to Go using Github's linguist tool

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.php linguist-language=Go


### PR DESCRIPTION
The repository is tagged "PHP" instead of Go since the liguist
tool sees a higher percentage of PHP rather than Go in the code.
It shows that PHP=98.2% and Go=1.8% but the tool is written in Go
so the intended language should be Go and not PHP.

This forces the linguist tool to change the repo laguage to
Go instead of PHP.

Signed-off-by: Alangi Derick <alangiderick@gmail.com>